### PR TITLE
Add basic Pester tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,3 +54,10 @@ That's it. Now just wait for iOS to sync over night all of the new photos import
 
 ## Further development
 If at some point in my life I have time I'll develop a more robust solution in a better programming language (Go, Rust, Zig... or even Python).
+
+## Running Tests
+Run all Pester tests with:
+
+```powershell
+Invoke-Pester
+```

--- a/tests/1-correctDatesParallelA.Tests.ps1
+++ b/tests/1-correctDatesParallelA.Tests.ps1
@@ -1,0 +1,34 @@
+Describe '1-correctDatesParallelA.ps1' {
+    BeforeAll {
+        $script:answers = @('', 'C:\\input', '')
+        $script:answerIndex = 0
+        Mock -CommandName Read-Host -MockWith { $script:answers[$script:answerIndex++] }
+        Mock -CommandName Get-ChildItem -MockWith { [pscustomobject]@{ FullName = 'file1.jpg'; Name = 'file1.jpg'; LastWriteTime = Get-Date; CreationTime = Get-Date } }
+        function ForEach-Object {
+            param(
+                [Parameter(ValueFromPipeline=$true)]$InputObject,
+                [scriptblock]$Process,
+                [int]$ThrottleLimit,
+                [switch]$Parallel
+            )
+            begin { $items = @() }
+            process { $items += $InputObject }
+            end { foreach($item in $items){ & $Process.Invoke($item) } }
+        }
+    }
+
+    Context 'ExifTool invocation' {
+        Mock -CommandName exiftool -MockWith { '2020:01:01 00:00:00' }
+        It 'calls exiftool to read and write metadata' {
+            . $PSScriptRoot/../1-correctDatesParallelA.ps1
+            Assert-MockCalled -CommandName exiftool -Times 2
+        }
+    }
+
+    Context 'Handles missing metadata' {
+        Mock -CommandName exiftool -MockWith { '' }
+        It 'does not throw when metadata is missing' {
+            { . $PSScriptRoot/../1-correctDatesParallelA.ps1 } | Should -Not -Throw
+        }
+    }
+}

--- a/tests/1-correctDatesParallelB.Tests.ps1
+++ b/tests/1-correctDatesParallelB.Tests.ps1
@@ -1,0 +1,34 @@
+Describe '1-correctDatesParallelB.ps1' {
+    BeforeAll {
+        $script:answers = @('', 'C:\\input', '')
+        $script:answerIndex = 0
+        Mock -CommandName Read-Host -MockWith { $script:answers[$script:answerIndex++] }
+        Mock -CommandName Get-ChildItem -MockWith { [pscustomobject]@{ FullName = 'file1.jpg'; Name = 'file1.jpg'; LastWriteTime = Get-Date; CreationTime = Get-Date } }
+        function ForEach-Object {
+            param(
+                [Parameter(ValueFromPipeline=$true)]$InputObject,
+                [scriptblock]$Process,
+                [int]$ThrottleLimit,
+                [switch]$Parallel
+            )
+            begin { $items = @() }
+            process { $items += $InputObject }
+            end { foreach($item in $items){ & $Process.Invoke($item) } }
+        }
+    }
+
+    Context 'ExifTool invocation' {
+        Mock -CommandName exiftool -MockWith { '2020:01:01 00:00:00' }
+        It 'calls exiftool to read and write metadata' {
+            . $PSScriptRoot/../1-correctDatesParallelB.ps1
+            Assert-MockCalled -CommandName exiftool -Times 2
+        }
+    }
+
+    Context 'Handles missing metadata' {
+        Mock -CommandName exiftool -MockWith { '' }
+        It 'does not throw when metadata is missing' {
+            { . $PSScriptRoot/../1-correctDatesParallelB.ps1 } | Should -Not -Throw
+        }
+    }
+}

--- a/tests/2-moveAlready.Tests.ps1
+++ b/tests/2-moveAlready.Tests.ps1
@@ -1,0 +1,31 @@
+Describe '2-moveAlready.ps1' {
+    BeforeAll {
+        $script:answers = @('', 'C:\\list.txt', 'C:\\src', 'C:\\dest', 'C:\\log.txt', '')
+        $script:answerIndex = 0
+        Mock -CommandName Read-Host -MockWith { $script:answers[$script:answerIndex++] }
+        Mock -CommandName Get-Content -MockWith { 'file1.jpg' }
+    }
+
+    Context 'Moves existing file' {
+        $call = 0
+        Mock -CommandName Test-Path -MockWith { param($path) if ($call -eq 0) { $call++; return $true } else { return $true } }
+        Mock -CommandName Move-Item {}
+        Mock -CommandName Out-File {}
+        It 'calls Move-Item when file exists' {
+            . $PSScriptRoot/../2-moveAlready.ps1
+            Assert-MockCalled -CommandName Move-Item -Times 1
+        }
+    }
+
+    Context 'Logs missing file' {
+        $call = 0
+        Mock -CommandName Test-Path -MockWith { param($path) if ($call -eq 0) { $call++; return $true } else { return $false } }
+        Mock -CommandName Move-Item {}
+        Mock -CommandName Out-File {}
+        It 'writes to log when file missing' {
+            . $PSScriptRoot/../2-moveAlready.ps1
+            Assert-MockCalled -CommandName Move-Item -Times 0
+            Assert-MockCalled -CommandName Out-File -Times 1
+        }
+    }
+}

--- a/tests/3-changeCodedMP4s.Tests.ps1
+++ b/tests/3-changeCodedMP4s.Tests.ps1
@@ -1,0 +1,36 @@
+Describe '3-changeCodedMP4s.ps1' {
+    BeforeAll {
+        $script:answers = @('C:\\src', 'C:\\dest')
+        $script:answerIndex = 0
+        Mock -CommandName Read-Host -MockWith { $script:answers[$script:answerIndex++] }
+        function ForEach-Object {
+            param(
+                [Parameter(ValueFromPipeline=$true)]$InputObject,
+                [scriptblock]$Process,
+                [int]$ThrottleLimit,
+                [switch]$Parallel
+            )
+            begin { $items = @() }
+            process { $items += $InputObject }
+            end { foreach($item in $items){ & $Process.Invoke($item) } }
+        }
+    }
+
+    Context 'Runs ffmpeg' {
+        Mock -CommandName Get-ChildItem -MockWith { [pscustomobject]@{ FullName = 'clip.3gp'; BaseName = 'clip' } }
+        Mock -CommandName Invoke-Expression {}
+        It 'invokes ffmpeg command' {
+            . $PSScriptRoot/../3-changeCodedMP4s.ps1
+            Assert-MockCalled -CommandName Invoke-Expression -Times 1 -ParameterFilter { $Command -like '*ffmpeg*' }
+        }
+    }
+
+    Context 'Handles no files' {
+        Mock -CommandName Get-ChildItem -MockWith { @() }
+        Mock -CommandName Invoke-Expression {}
+        It 'does not call ffmpeg when no files found' {
+            . $PSScriptRoot/../3-changeCodedMP4s.ps1
+            Assert-MockCalled -CommandName Invoke-Expression -Times 0
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Pester tests for all PowerShell scripts
- document how to run the tests

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*