### PR TITLE
Add simple GUI runner for processing scripts

### DIFF
--- a/1-correctDatesParallelA.ps1
+++ b/1-correctDatesParallelA.ps1
@@ -1,11 +1,20 @@
-# Wait for the user to press Enter to start
-Read-Host "Press Enter to start processing files"
+# Adds a parameter so the script can be executed non-interactively
+param(
+    [string]$TargetDirectory,
+    [switch]$NoPause
+)
 
-# Define the target directory
-$targetDirectory = "C:\Users\Daniel Bañuelos\Desktop\takeout-20240305T230527Z-001\3gps"
+if (-not $NoPause) {
+    Read-Host "Press Enter to start processing files"
+}
+
+# If a directory wasn't supplied use a default path or prompt the user
+if (-not $TargetDirectory) {
+    $TargetDirectory = "C:\Users\Daniel Bañuelos\Desktop\takeout-20240305T230527Z-001\3gps"
+}
 
 # Get all files in the directory
-$files = Get-ChildItem $targetDirectory -File
+$files = Get-ChildItem $TargetDirectory -File
 
 # Throttle limit can be adjusted based on your system's capabilities
 $throttleLimit = 12
@@ -49,5 +58,7 @@ $files | ForEach-Object -Parallel {
     }
 } -ThrottleLimit $throttleLimit
 
-Write-Host "Processing complete. Press Enter to exit." -ForegroundColor DarkGreen
-Read-Host "Press Enter to exit"
+Write-Host "Processing complete." -ForegroundColor DarkGreen
+if (-not $NoPause) {
+    Read-Host "Press Enter to exit"
+}

--- a/1-correctDatesParallelB.ps1
+++ b/1-correctDatesParallelB.ps1
@@ -1,11 +1,20 @@
-# Wait for the user to press Enter to start
-Read-Host "Press Enter to start processing files"
+# Adds a parameter so the script can be executed non-interactively
+param(
+    [string]$TargetDirectory,
+    [switch]$NoPause
+)
 
-# Define the target directory
-$targetDirectory = "C:\Users\Daniel Bañuelos\Desktop\takeout-20240305T230527Z-001\outputmp4s"
+if (-not $NoPause) {
+    Read-Host "Press Enter to start processing files"
+}
+
+# If a directory wasn't supplied use a default path or prompt the user
+if (-not $TargetDirectory) {
+    $TargetDirectory = "C:\Users\Daniel Bañuelos\Desktop\takeout-20240305T230527Z-001\outputmp4s"
+}
 
 # Get all files in the directory
-$files = Get-ChildItem $targetDirectory -File
+$files = Get-ChildItem $TargetDirectory -File
 
 # Throttle limit can be adjusted based on your system's capabilities
 $throttleLimit = 12
@@ -52,5 +61,7 @@ $files | ForEach-Object -Parallel {
     }
 } -ThrottleLimit $throttleLimit
 
-Write-Host "Processing complete. Press Enter to exit." -ForegroundColor DarkGreen
-Read-Host "Press Enter to exit"
+Write-Host "Processing complete." -ForegroundColor DarkGreen
+if (-not $NoPause) {
+    Read-Host "Press Enter to exit"
+}

--- a/GuiProcess.ps1
+++ b/GuiProcess.ps1
@@ -1,0 +1,75 @@
+# Simple GUI wrapper for the processing scripts
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+
+$form = New-Object System.Windows.Forms.Form
+$form.Text = 'Google Takeout Processor'
+$form.Size = New-Object System.Drawing.Size(400,180)
+$form.StartPosition = 'CenterScreen'
+
+$label = New-Object System.Windows.Forms.Label
+$label.Text = 'Select Google Takeout folder:'
+$label.AutoSize = $true
+$label.Location = New-Object System.Drawing.Point(10,20)
+$form.Controls.Add($label)
+
+$textBox = New-Object System.Windows.Forms.TextBox
+$textBox.Location = New-Object System.Drawing.Point(10,40)
+$textBox.Width = 280
+$form.Controls.Add($textBox)
+
+$browse = New-Object System.Windows.Forms.Button
+$browse.Text = 'Browse...'
+$browse.Location = New-Object System.Drawing.Point(300,38)
+$form.Controls.Add($browse)
+
+$run = New-Object System.Windows.Forms.Button
+$run.Text = 'Run'
+$run.Location = New-Object System.Drawing.Point(10,80)
+$form.Controls.Add($run)
+
+$progressBar = New-Object System.Windows.Forms.ProgressBar
+$progressBar.Style = 'Marquee'
+$progressBar.Location = New-Object System.Drawing.Point(10,120)
+$progressBar.Width = 360
+$progressBar.Visible = $false
+$form.Controls.Add($progressBar)
+
+$folderDialog = New-Object System.Windows.Forms.FolderBrowserDialog
+
+$browse.add_Click({
+    if ($folderDialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
+        $textBox.Text = $folderDialog.SelectedPath
+    }
+})
+
+$run.add_Click({
+    $folder = $textBox.Text
+    if (-not (Test-Path $folder)) {
+        [System.Windows.Forms.MessageBox]::Show('Please select a valid folder.')
+        return
+    }
+    $progressBar.Visible = $true
+    $run.Enabled = $false
+    $browse.Enabled = $false
+
+    $job = Start-Job -ArgumentList $folder -ScriptBlock {
+        param($dir)
+        & "$PSScriptRoot\1-correctDatesParallelA.ps1" -TargetDirectory $dir -NoPause
+    }
+
+    $timer = New-Object System.Windows.Forms.Timer
+    $timer.Interval = 1000
+    $timer.add_Tick({
+        if ($job.State -eq 'Completed') {
+            $timer.Stop()
+            $progressBar.Visible = $false
+            $run.Enabled = $true
+            $browse.Enabled = $true
+            [System.Windows.Forms.MessageBox]::Show('Processing complete.')
+        }
+    })
+    $timer.Start()
+})
+
+[System.Windows.Forms.Application]::Run($form)


### PR DESCRIPTION
## Summary
- add a Windows Forms GUI (`GuiProcess.ps1`) that lets the user pick a folder and runs `1-correctDatesParallelA.ps1`
- allow `1-correctDatesParallelA.ps1` and `1-correctDatesParallelB.ps1` to receive a target directory and run without pauses

## Testing
- `git status --short`