### PR TITLE
Fix undefined variable output

### DIFF
--- a/1-correctDatesParallelA.ps1
+++ b/1-correctDatesParallelA.ps1
@@ -43,7 +43,7 @@ $files | ForEach-Object -Parallel {
         $file.CreationTime = $correctDate
 
 
-        Write-Host "F: $($file.Name) `n CD: $dateStringWithoutMilliseconds `n DTO: $dateTimeOriginal `n`n" -ForegroundColor DarkGreen
+        Write-Host "F: $($file.Name) `n CD: $dateStringWithoutMilliseconds `n`n" -ForegroundColor DarkGreen
     } else {
         Write-Host "ERROR NO VALID DATE FOUND FOR FILE: $($file.Name) `n`n" -ForegroundColor DarkRed
     }


### PR DESCRIPTION
## Summary
- remove `$dateTimeOriginal` from the output in `1-correctDatesParallelA.ps1`

## Testing
- `pwsh -v` *(fails: command not found)*